### PR TITLE
Fail with a nice error message if running on XP

### DIFF
--- a/src/Setup/FxHelper.cpp
+++ b/src/Setup/FxHelper.cpp
@@ -6,6 +6,19 @@
 static const wchar_t* ndpPath = L"SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full";
 static const int fx45ReleaseVersion = 378389;
 
+// According to https://msdn.microsoft.com/en-us/library/8z6watww%28v=vs.110%29.aspx,
+// to install .NET 4.5 we must be Vista SP2+, Windows 7 SP1+, or later.
+bool CFxHelper::CanInstallDotNet4_5()
+{
+	if (!IsWindowsVistaSP2OrGreater())
+		return false;
+	if (IsWindows7SP1OrGreater())
+		return true;
+	// At this point, we might be: an acceptable version of Vista, or an unacceptable version of Win7.
+	// Being windows 7 is the remaining failure case.
+	return !IsWindows7OrGreater();
+}
+
 bool CFxHelper::IsDotNet45OrHigherInstalled()
 {
 	ATL::CRegKey key;

--- a/src/Setup/FxHelper.h
+++ b/src/Setup/FxHelper.h
@@ -3,6 +3,7 @@
 class CFxHelper
 {
 public:
+	static bool CanInstallDotNet4_5();
 	static bool IsDotNet45OrHigherInstalled();
 	static HRESULT InstallDotNetFramework(bool isQuiet);
 private:

--- a/src/Setup/Setup.vcxproj
+++ b/src/Setup/Setup.vcxproj
@@ -29,7 +29,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/src/Setup/winmain.cpp
+++ b/src/Setup/winmain.cpp
@@ -23,6 +23,14 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 	CString cmdLine(lpCmdLine);
 	bool isQuiet = (cmdLine.Find(L"-s") >= 0);
 
+	if (!CFxHelper::CanInstallDotNet4_5())
+	{
+		// Explain this as nicely as possible and give up.
+		MessageBox(0L, L"This program cannot run on this sytem; it requires Windows Vista SP2 or Windows 7 SP1 or a later version.", L"Incompatible Operating System", 0);
+		exitCode = E_FAIL;
+		goto out;
+	}
+
 	if (!CFxHelper::IsDotNet45OrHigherInstalled()) {
 		hr = CFxHelper::InstallDotNetFramework(isQuiet);
 		if (FAILED(hr)) {


### PR DESCRIPTION
(or on various other OS's that can't install .NET 4.5)
Using PlatformToolset v120_xp allows Setup.exe itself to run on XP,
since it is already a 32-bit application. But installing the service pack
will fail quietly, so give a nice message rather than attempting it.
