### PR TITLE
Try repeatedly to get deltas before resorting to whole-package download

### DIFF
--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -36,8 +36,8 @@ namespace Squirrel
                 await this.WarnIfThrows(() => wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile),
                     "Failed downloading URL: " + (failedUrl ?? url));
             } catch (Exception) {
-				if (File.Exists(targetFile))
-					File.Delete(targetFile); // don't leave incomplete downloads around
+                if (File.Exists(targetFile))
+                    File.Delete(targetFile); // don't leave incomplete downloads around
                 // NB: Some super brain-dead services are case-sensitive yet 
                 // corrupt case on upload. I can't even.
                 if (failedUrl != null) throw;

--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using Splat;
@@ -35,6 +36,8 @@ namespace Squirrel
                 await this.WarnIfThrows(() => wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile),
                     "Failed downloading URL: " + (failedUrl ?? url));
             } catch (Exception) {
+				if (File.Exists(targetFile))
+					File.Delete(targetFile); // don't leave incomplete downloads around
                 // NB: Some super brain-dead services are case-sensitive yet 
                 // corrupt case on upload. I can't even.
                 if (failedUrl != null) throw;

--- a/src/Squirrel/FileDownloader.cs
+++ b/src/Squirrel/FileDownloader.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using Splat;
@@ -36,8 +35,6 @@ namespace Squirrel
                 await this.WarnIfThrows(() => wc.DownloadFileTaskAsync(failedUrl ?? url, targetFile),
                     "Failed downloading URL: " + (failedUrl ?? url));
             } catch (Exception) {
-                if (File.Exists(targetFile))
-                    File.Delete(targetFile); // don't leave incomplete downloads around
                 // NB: Some super brain-dead services are case-sensitive yet 
                 // corrupt case on upload. I can't even.
                 if (failedUrl != null) throw;

--- a/src/Squirrel/UpdateManager.DownloadReleases.cs
+++ b/src/Squirrel/UpdateManager.DownloadReleases.cs
@@ -113,23 +113,18 @@ namespace Squirrel
                 var targetPackage = new FileInfo(
                     Path.Combine(rootAppDirectory, "packages", downloadedRelease.Filename));
 
-                if (!targetPackage.Exists)
-                {
+                if (!targetPackage.Exists) {
                     return false;
                 }
 
-                if (targetPackage.Length != downloadedRelease.Filesize)
-                {
+                if (targetPackage.Length != downloadedRelease.Filesize) {
                     return false;
                 }
 
-                using (var file = targetPackage.OpenRead())
-                {
+                using (var file = targetPackage.OpenRead()) {
                     var hash = Utility.CalculateStreamSHA1(file);
-
                     return hash.Equals(downloadedRelease.SHA1, StringComparison.OrdinalIgnoreCase);
                 }
-                
             }
 
             void checksumPackage(ReleaseEntry downloadedRelease)


### PR DESCRIPTION
Further improved to avoid downloading anything we already got, including downloads that were obtained on an earlier run of the program (but not fully applied).
Also improves robustness: if we somehow get an invalid download we will retry it.
