### PR TITLE
If the process already has a console, write to that.

### DIFF
--- a/src/Update/NativeMethods.cs
+++ b/src/Update/NativeMethods.cs
@@ -53,6 +53,9 @@ namespace Squirrel.Update
         [DllImport("kernel32.dll")]
         public static extern bool AttachConsole(int pid);
 
+		[DllImport("kernel32.dll", SetLastError = true)]
+		public static extern IntPtr GetConsoleWindow();
+
         [DllImport("Kernel32.dll", SetLastError=true)]
         public static extern IntPtr BeginUpdateResource(string pFileName, bool bDeleteExistingResources);
 

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -127,18 +127,35 @@ namespace Squirrel.Update
                 var unknownArgs = opts.Parse(args);
 
                 if (updateAction == UpdateAction.Unset) {
-                    //ShowHelp();
-                    MessageBox.Show("Update.exe called with no recognized command. Arguments were " +
-                                    string.Join(" ", args));
-                    return -1;
+					var message = "Update.exe called with no recognized command. Arguments were " +
+											string.Join(" ", args);
+	                if (NativeMethods.GetConsoleWindow() != IntPtr.Zero)
+	                {
+						// already have a console, run from command line, don't UI.
+						Console.WriteLine(message);
+		                ShowHelp();
+	                }
+	                else
+		                MessageBox.Show(message);
+	                return -1;
                 }
 
                 if (unknownArgs.Any())
                 {
-                    MessageBox.Show("Update.exe called with unexpected arguments: " + string.Join(" ", unknownArgs) +
-                                    ". Full arguments were " +
-                                    string.Join(" ", args));
-                    return -1;
+					var message = "Update.exe called with unexpected arguments: " + string.Join(" ", unknownArgs) +
+											". Full arguments were " +
+											string.Join(" ", args);
+					if (NativeMethods.GetConsoleWindow() == IntPtr.Zero)
+					{
+						// already have a console, run from command line, don't UI.
+						Console.WriteLine(message);
+						ShowHelp();
+					}
+					else
+	                {
+		                MessageBox.Show(message);
+	                }
+	                return -1;
                 }
 
                 switch (updateAction) {

--- a/src/Update/Program.cs
+++ b/src/Update/Program.cs
@@ -127,35 +127,35 @@ namespace Squirrel.Update
                 var unknownArgs = opts.Parse(args);
 
                 if (updateAction == UpdateAction.Unset) {
-					var message = "Update.exe called with no recognized command. Arguments were " +
-											string.Join(" ", args);
-	                if (NativeMethods.GetConsoleWindow() != IntPtr.Zero)
-	                {
-						// already have a console, run from command line, don't UI.
-						Console.WriteLine(message);
-		                ShowHelp();
-	                }
-	                else
-		                MessageBox.Show(message);
-	                return -1;
+                    var message = "Update.exe called with no recognized command. Arguments were " +
+                                            string.Join(" ", args);
+                    if (NativeMethods.GetConsoleWindow() != IntPtr.Zero)
+                    {
+                        // already have a console, run from command line, don't UI.
+                        Console.WriteLine(message);
+                        ShowHelp();
+                    }
+                    else
+                        MessageBox.Show(message);
+                    return -1;
                 }
 
                 if (unknownArgs.Any())
                 {
-					var message = "Update.exe called with unexpected arguments: " + string.Join(" ", unknownArgs) +
-											". Full arguments were " +
-											string.Join(" ", args);
-					if (NativeMethods.GetConsoleWindow() == IntPtr.Zero)
-					{
-						// already have a console, run from command line, don't UI.
-						Console.WriteLine(message);
-						ShowHelp();
-					}
-					else
-	                {
-		                MessageBox.Show(message);
-	                }
-	                return -1;
+                    var message = "Update.exe called with unexpected arguments: " + string.Join(" ", unknownArgs) +
+                                            ". Full arguments were " +
+                                            string.Join(" ", args);
+                    if (NativeMethods.GetConsoleWindow() != IntPtr.Zero)
+                    {
+                        // already have a console, run from command line, don't UI.
+                        Console.WriteLine(message);
+                        ShowHelp();
+                    }
+                    else
+                    {
+                        MessageBox.Show(message);
+                    }
+                    return -1;
                 }
 
                 switch (updateAction) {


### PR DESCRIPTION
This prevents freezing an unattended build.
